### PR TITLE
Continued setup

### DIFF
--- a/packages/common/components/blocks/ad/emailx.marko
+++ b/packages/common/components/blocks/ad/emailx.marko
@@ -1,5 +1,5 @@
 import { getAsObject, get } from "@parameter1/base-cms-object-path";
-import defaultValue from "@parameter1/base-cms-marko-core/utils/deault-value";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const adUnit = getAsObject(input, "adUnit");
 $ const dpm = getAsObject(input, "dpm");
@@ -34,7 +34,7 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
               </marko-core-img>
             </td>
           </tr>
-          <common-table-spaceer-element height="30" />
+          <common-table-spacer-element height="30" />
         </table>
       </td>
     </tr>

--- a/packages/common/components/blocks/body-wrapper.marko
+++ b/packages/common/components/blocks/body-wrapper.marko
@@ -25,7 +25,7 @@ $ const { newsletter, date } = input;
               <${input.footer} />
             </if>
             <else>
-              <commont-footer-block date=date newsletter=newsletter />
+              <common-footer-block date=date newsletter=newsletter />
             </else>
 
           </table>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -6,8 +6,9 @@ $ const topSpacer = defaultValue(input.topSpacer, "15");
 $ const contentStylingTitle = {
   "font-size": "18px",
   "line-height": "20px",
-  "color": "000",
-  "font-weight": "700"
+  "color": "#000",
+  "font-weight": "700",
+  "letter-spacing": "0.2px"
 }
 
 $ const contentStyling = {
@@ -29,11 +30,13 @@ $ const hasLogo = input.hasLogo || false
 $ const { content } = input;
 $ const withImage = defaultValue(input.withImage, true);
 
+$ const blackLine = {
+  "border-bottom": "1px solid #6f6f6f"
+}
 
 <tr>
   <td align="center" valign="top">
     <table width="100%" border="0" cellspacing="0" cellpadding="0" class="wrap23">
-      <common-table-spacer-element height="3" style="solid: #6f6f6f" />
       <if (isAd)>
         <tr>
           <td align="center" vaign="top" style="font-size: 9px;line-height: 12px;color: #000000;font-weight: 300;"> PAID ADVERTISEMENT</td>
@@ -42,14 +45,14 @@ $ const withImage = defaultValue(input.withImage, true);
       <tr>
         <td align="center" valign="top">
           <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="18" style="solid: #6f6f6f" />
+            <common-table-spacer-element height="18" />
             <tr>
               <td align="center" valign="top">
                 <table width="100%" border="0"  cellspacing="0" cellpadding="0">
                   <tr>
                     <td align="center" valign="top">
                       <table width="85%" border="0" cellspacing="0" callpadding="0">
-                      <common-table-spacer-element height="18" style="solid: #6f6f6f" />
+                      <common-table-spacer-element height="18" />
                       <tr>
                         <td align="left" valign="top" width="54.6%" class="split1">
                           <table width="100%" border="0"  cellspacing="0" cellpadding="0">
@@ -74,7 +77,7 @@ $ const withImage = defaultValue(input.withImage, true);
           </table>
         </td>
       </tr>
-      <common-table-spacer-element height="13" style="solid: #6f6f6f" style="solid: #6f6f6f" />
+      <common-table-spacer-element height="13" style=blackLine />
     </table>
   </td>
 </tr>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -47,10 +47,3 @@ $ const teaser = input.teaser || ""
     </table>
   </td>
 </tr>
-<if(button)>
-  <tr>
-    <td>
-      <common-content-button-element content=content />
-    </td>
-  </tr>
-</if>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -19,14 +19,47 @@ $ const contentStyling = {
 
 $ const title = input.title || ""
 $ const teaser = input.teaser || ""
+$ const withLink = input.withLink || false
+$ const isAd = input.isAd || false
+$ const hasLogo = input.hasLogo || false
 
 <tr>
   <td align="center" valign="top">
     <table width="100%" border="0" cellspacing="0" cellpadding="0" class="wrap23">
+      <common-table-spacer-element height="3" />
+      <if (isAd)>
+        <tr>
+          <td align="center" vaign="top" style="font-size: 9px;line-height: 12px;color: #000000;font-weight: 300;"> PAID ADVERTISEMENT</td>
+        </tr>
+      </if>
       <tr>
         <td align="center" valign="top">
           <table width="100%" border="0" cellspacing="0" cellpadding="0">
             <common-table-spacer-element height="18" />
+            <if (isAd)>
+            <tr>
+            <td  align="left" valign="top" width="54.6%" class="split1">
+            <table width="100%" border="0"  cellspacing="0" cellpadding="0">
+            <common-table-spacer-element height="9" />
+            <tr>
+            <tr>
+              <common-content-image-element align="left" valign="top" class="resize" src=input.logoImage width="105" height="35" alt=input.logoImage/>
+              </tr>
+               <common-table-spacer-element height="13" />
+              <tr>
+              <td align="left" valign="top" style=contentStylingTitle >${title}</td>
+              </tr>
+              <tr>
+              <td align="left" valign="top" style=contentStyling >${teaser}<if (withLink)><a href=input.linkValue style="color: #000000;text-decoration: underline;">${input.linkText}</a></if></td>
+              </tr>
+            </tr>
+            </table>
+            </td>
+            <common-content-image-element align="left" valign="top" class="wrap12 split1" src="images/img2.png" width="230" height="185" alt="img2"/>
+            </tr>
+            <common-table-spacer-element height="13" />
+            </if>
+            <else>
             <tr>
               <td align="left" valign="top" width="54.6%" class="split1">
                 <table width="100%" border="0"  cellspacing="0" cellpadding="0">
@@ -34,12 +67,13 @@ $ const teaser = input.teaser || ""
                     <td align="left" valign="top" style=contentStylingTitle >${title}</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style=contentStyling >${teaser}<a href="#" style="color: #000000;text-decoration: underline;"> Register Now.</a></td>
+                    <td align="left" valign="top" style=contentStyling >${teaser}<if (withLink)><a href=input.linkValue style="color: #000000;text-decoration: underline;">${input.linkText}</a></if></td>
                   </tr>
                 </table>
               </td>
               <common-content-image-element align="left" valign="top" class="wrap12 split1" src="images/img2.png" width="231" height="184" alt="img2"/>
             </tr>
+            </else>
           </table>
         </td>
       </tr>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -2,19 +2,23 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const topSpacer = defaultValue(input.topSpacer, "15");
 
-$ const contentStylingTitle {
+$ const contentStylingTitle = {
   "font-size": "18px",
   "line-height": "20px",
   "color": "000",
   "font-weight": "700"
 }
 
-$ const contentStyling {
+$ const contentStyling = {
   "font-size": "14px",
-  "line-height": "18px"
+  "line-height": "18px",
   "color": "#000000",
-  "font-weight": "400"
+  "font-weight": "400",
+  "letter-spacing": "-0.3px"
 }
+
+$ const title = input.title || ""
+$ const teaser = input.teaser || ""
 
 <tr>
   <td align="center" valign="top">
@@ -27,10 +31,10 @@ $ const contentStyling {
               <td align="left" valign="top" width="54.6%" class="split1">
                 <table width="100%" border="0"  cellspacing="0" cellpadding="0">
                   <tr>
-                    <td align="left" valign="top" style=contentStylingTitle >Save the date for 2022</td>
+                    <td align="left" valign="top" style=contentStylingTitle >${title}</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style="font-size: 14px;line-height: 18px;color: #000000;font-weight: 400;letter-spacing: -0.3px;">Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Vitaqui ius estem. Ovid excepeliqui luptatem ipis sunt. Ovid excepeliqui doluptatem ipis experum.<a href="#" style="color: #000000;text-decoration: underline;"> Register Now.</a></td>
+                    <td align="left" valign="top" style=contentStyling >${teaser}<a href="#" style="color: #000000;text-decoration: underline;"> Register Now.</a></td>
                   </tr>
                 </table>
               </td>
@@ -50,6 +54,3 @@ $ const contentStyling {
     </td>
   </tr>
 </if>
-<else>
-  <tr>
-    <td>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -1,4 +1,5 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { get, getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const topSpacer = defaultValue(input.topSpacer, "15");
 
@@ -17,16 +18,22 @@ $ const contentStyling = {
   "letter-spacing": "-0.3px"
 }
 
+//Temporary Parameters for Testing
 $ const title = input.title || ""
 $ const teaser = input.teaser || ""
 $ const withLink = input.withLink || false
 $ const isAd = input.isAd || false
 $ const hasLogo = input.hasLogo || false
 
+//Actual parameters once ready
+$ const { content } = input;
+$ const withImage = defaultValue(input.withImage, true);
+
+
 <tr>
   <td align="center" valign="top">
     <table width="100%" border="0" cellspacing="0" cellpadding="0" class="wrap23">
-      <common-table-spacer-element height="3" />
+      <common-table-spacer-element height="3" style="solid: #6f6f6f" />
       <if (isAd)>
         <tr>
           <td align="center" vaign="top" style="font-size: 9px;line-height: 12px;color: #000000;font-weight: 300;"> PAID ADVERTISEMENT</td>
@@ -35,49 +42,39 @@ $ const hasLogo = input.hasLogo || false
       <tr>
         <td align="center" valign="top">
           <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="18" />
-            <if (isAd)>
+            <common-table-spacer-element height="18" style="solid: #6f6f6f" />
             <tr>
-            <td  align="left" valign="top" width="54.6%" class="split1">
-            <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="9" />
-            <tr>
-            <tr>
-              <common-content-image-element align="left" valign="top" class="resize" src=input.logoImage width="105" height="35" alt=input.logoImage/>
-              </tr>
-               <common-table-spacer-element height="13" />
-              <tr>
-              <td align="left" valign="top" style=contentStylingTitle >${title}</td>
-              </tr>
-              <tr>
-              <td align="left" valign="top" style=contentStyling >${teaser}<if (withLink)><a href=input.linkValue style="color: #000000;text-decoration: underline;">${input.linkText}</a></if></td>
-              </tr>
-            </tr>
-            </table>
-            </td>
-            <common-content-image-element align="left" valign="top" class="wrap12 split1" src="images/img2.png" width="230" height="185" alt="img2"/>
-            </tr>
-            <common-table-spacer-element height="13" />
-            </if>
-            <else>
-            <tr>
-              <td align="left" valign="top" width="54.6%" class="split1">
+              <td align="center" valign="top">
                 <table width="100%" border="0"  cellspacing="0" cellpadding="0">
                   <tr>
-                    <td align="left" valign="top" style=contentStylingTitle >${title}</td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style=contentStyling >${teaser}<if (withLink)><a href=input.linkValue style="color: #000000;text-decoration: underline;">${input.linkText}</a></if></td>
+                    <td align="center" valign="top">
+                      <table width="85%" border="0" cellspacing="0" callpadding="0">
+                      <common-table-spacer-element height="18" style="solid: #6f6f6f" />
+                      <tr>
+                        <td align="left" valign="top" width="54.6%" class="split1">
+                          <table width="100%" border="0"  cellspacing="0" cellpadding="0">
+                          <if (isAd)>
+                            <tr>
+                              <common-content-image-element align="left" valign="top" classValueTD="resize" src=input.logoImage width="105" height="35" alt=input.logoImage/>
+                            </tr>
+                          </if>
+                          <tr><common-content-image-element align="center" valign="top" class="wrap11" src="images/img2.png" width="231" height="184" alt="img2"/></tr>
+                          <tr><td align="left" valign="top" style=contentStylingTitle >${title}</td></tr>
+                          <tr><td align="left" valign="top" style=contentStyling >${teaser}<if (withLink)><a href=input.linkValue style="color: #000000;text-decoration: underline;">${input.linkText}</a></if></td></tr>
+                          </table>
+                        </td>
+                        <common-content-image-element align="left" valign="top" class="wrap12 split1" src="images/img2.png" width="231" height="184" alt="img2"/>
+                      </tr>
+                      </table>
+                    </td>
                   </tr>
                 </table>
               </td>
-              <common-content-image-element align="left" valign="top" class="wrap12 split1" src="images/img2.png" width="231" height="184" alt="img2"/>
             </tr>
-            </else>
           </table>
         </td>
       </tr>
-      <common-table-spacer-element height="13" style="solid #6f6f6f" />
+      <common-table-spacer-element height="13" style="solid: #6f6f6f" style="solid: #6f6f6f" />
     </table>
   </td>
 </tr>

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -1,13 +1,28 @@
-import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-<!-- import { URLSearchParams } from "url";
+// import queryFragment from // SOMEWHERE
 
-$ const { content, urlParams } = input; -->
+$ const { newsletter, date } = input;
 
-$ const withImage = defaultValue(input.withImage, false);
-$ const imagePostions = defaultValue(input.imagePosition, 'right');
-$ const withSection = defaultValue(input.withSection, true);
+$ const sectionName = defaultValue(input.sectionName, "Standard");
+$ const sectionDescription = defaultValue(input.sectionDescription, "Articles, events and sponsored content to consider");
+$ const withImage = defaultValue(input.withImage, true);
 
+$ /*const queryParams = {
+  date: date.valueOf(),
+  newsletterId: newsletter.id,
+  sectionName,
+  limit: input.limit || 1,
+  skip: input.skip || 0,
+  queryFragment,
+}; */
+<!--
+<marko-web-query|{nodes}| name="newsletter-scheduled-content" collapsible=false params=queryParams>
+  <if(nodes.length)>
+  <for|content| of=nodes>
+    <common-content-list-item-block content=content with-Image=withImage />
+  </for>
+  </if>
+</marko-web-query>-->
 
 
 <!--4th block Start -->

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -11,37 +11,8 @@ $ const withSection = defaultValue(input.withSection, true);
 
 
 <!--4th block Start -->
-<common-content-list-item-block title="Save the date for 2022" teaser="Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Vitaqui ius estem. Ovid excepeliqui luptatem ipis sunt. Ovid excepeliqui doluptatem ipis experum."/>
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" class="wrap23">
-      <tr>
-        <td align="center" valign="top">
-          <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="18" />
-            <tr>
-              <td align="left" valign="top" width="54.6%" class="split1">
-                <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td align="center" valign="top"><img src="images/img2.png" width="231" height="184" alt="img2" class="wrap11"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 17px;line-height: 19px;color: #000;font-weight: 700;letter-spacing: 0.2px;">Save the date for 2022</td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 14px;line-height: 18px;color: #000000;font-weight: 400;letter-spacing: -0.3px;">Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Vitaqui ius estem. Ovid excepeliqui luptatem ipis sunt. Ovid excepeliqui doluptatem ipis experum.<a href="#" style="color: #000000;text-decoration: underline;"> Register Now.</a></td>
-                  </tr>
-                </table>
-              </td>
-              <td align="left" valign="top" class="wrap12 split1"><img src="images/img2.png" width="231" height="184" alt="img2"></td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <common-table-spacer-element height="13" style="solid #6f6f6f" />
-    </table>
-  </td>
-</tr>
+<common-content-list-item-block title="Save the date for 2022" teaser="Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Vitaqui ius estem. Ovid excepeliqui luptatem ipis sunt. Ovid excepeliqui doluptatem ipis experum." withLink=true linkValue="#" linkText="Register Now"/>
+<common-content-list-item-block title="Rezum™ Water Vapor Therapy" teaser="Volorem quisqua tendaer fersper sperferibus as preium voluptatis sum in res sanihil latures sam nobis" withLink=false isAd=true hasLogo=true logoImage="images/image5.png"/>
 <!--4th block End -->
 <!--5th block Start -->
 <tr>
@@ -49,7 +20,7 @@ $ const withSection = defaultValue(input.withSection, true);
     <table width="100%" border="0" cellspacing="0" cellpadding="0" class="wrap23">
       <common-table-spacer-element height="3" />
       <tr>
-        <td align="center" vaign="top" style="font-size: 9px;line-height: 12px;color: #000000;font-weight: 300;"> PAID ADVERTISEMENT</td>
+        <td align="center" valign="top" style="font-size: 9px;line-height: 12px;color: #000000;font-weight: 300;"> PAID ADVERTISEMENT</td>
       </tr>
       <tr>
         <td align="center" valign="top">

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -11,6 +11,7 @@ $ const withSection = defaultValue(input.withSection, true);
 
 
 <!--4th block Start -->
+<common-content-list-item-block title="Save the date for 2022" teaser="Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Vitaqui ius estem. Ovid excepeliqui luptatem ipis sunt. Ovid excepeliqui doluptatem ipis experum."/>
 <tr>
   <td align="center" valign="top">
     <table width="100%" border="0" cellspacing="0" cellpadding="0" class="wrap23">

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -64,17 +64,7 @@ $ /*const queryParams = {
 <!--13th block end-->
 
 <!--14th block start-->
-<common-table-spacer-element height="15" />
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" cellpadding="0" cellspacing="0">
-      <tr>
-        <td align="left" valign="top" style="font-weight: 700;font-size: 19px;line-height: 20px;"><span style="color: #e55b3d;font-weight: 700;font-size: 18px;line-height: 20px;letter-spacing: -0.2px;">Download the Annual Meeting Mobile App</span> and discover more at your fingertips. This is an example of a headline with no image or teaser.</td>
-      </tr>
-    </table>
-  </td>
-</tr>
-<common-table-spacer-element height="8" />
+<common-content-list-item-block title="Download the Annual Meeting Mobile App</span> and discover more at your fingertips. This is an example of a headline with no image or teaser." />
 <!--14th block end-->
 
 <!--15th block start
@@ -82,37 +72,7 @@ $ /*const queryParams = {
 <!--15th block end-->
 
 <!--16th block start-->
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-      <tr>
-        <td align="center" valign="top">
-          <table width="83%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="17" />
-
-            <tr>
-              <td  align="left" valign="top" width="54.6%" class="split1">
-                <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td align="center" valign="top"><img src="images/img9.png" width="231" height="185" alt="img9" class="wrap11"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 16px;line-height: 20px;color: #000;font-weight: 700;letter-spacing: 0.3px;">CDC provides safe guidelines as gathering size limitations begin to expand. </td>
-                  </tr>
-                  <common-table-spacer-element height="15" />
-
-                </table>
-              </td>
-              <td align="left" valign="top" class="wrap12 split1"><img src="images/img9.png" width="231" height="185" alt="img9"></td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <common-table-spacer-element height="15" />
-
-    </table>
-  </td>
-</tr>
+<common-content-list-item-block title="CDC provides safe guidelines as gathering size limitations begin to expand." />
 <!--16th block end-->
 
 <!--17th block start

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -12,195 +12,39 @@ $ const withSection = defaultValue(input.withSection, true);
 
 <!--4th block Start -->
 <common-content-list-item-block title="Save the date for 2022" teaser="Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Vitaqui ius estem. Ovid excepeliqui luptatem ipis sunt. Ovid excepeliqui doluptatem ipis experum." withLink=true linkValue="#" linkText="Register Now"/>
-<common-content-list-item-block title="Rezum™ Water Vapor Therapy" teaser="Volorem quisqua tendaer fersper sperferibus as preium voluptatis sum in res sanihil latures sam nobis" withLink=false isAd=true hasLogo=true logoImage="images/image5.png"/>
 <!--4th block End -->
 <!--5th block Start -->
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" class="wrap23">
-      <common-table-spacer-element height="3" />
-      <tr>
-        <td align="center" valign="top" style="font-size: 9px;line-height: 12px;color: #000000;font-weight: 300;"> PAID ADVERTISEMENT</td>
-      </tr>
-      <tr>
-        <td align="center" valign="top">
-          <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="5" />
-            <tr>
-              <td  align="left" valign="top" width="54.6%" class="split1">
-                <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-                  <common-table-spacer-element height="9" />
-                  <tr>
-                    <td align="left" valign="top" class="resize"><img src="images/img5.png" width="106" height="35" alt="img5"></td>
-                  </tr>
-                  <tr>
-                    <td align="center" valign="top"><img src="images/img3.png" width="231" height="184" alt="img3" class="wrap11"></td>
-                  </tr>
-                  <common-table-spacer-element height="13" />
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 18px;line-height: 23px;color: #000;font-weight: 700;letter-spacing: -0.3px;">Rezum™ Water Vapor Therapy </td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 14px;line-height: 17px;color: #000000;font-weight: 400;">Volorem quisqua tendaer fersper sperferibus as preium voluptatis sum in res sanihil latures sam nobis</td>
-                  </tr>
-                </table>
-              </td>
-              <td align="left" valign="top" class="wrap12 split1"><img src="images/img3.png" width="231" height="184" alt="img3"></td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <common-table-spacer-element height="15" style="solid #6f6f6f" />
-    </table>
-  </td>
-</tr>
+<common-content-list-item-block title="Rezum™ Water Vapor Therapy" teaser="Volorem quisqua tendaer fersper sperferibus as preium voluptatis sum in res sanihil latures sam nobis" isAd=true hasLogo=true logoImage="images/image5.png"/>
 <!--5th block End -->
 <!--6th block Start -->
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-      <tr>
-        <td align="center" valign="top">
-          <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="16" />
-            <tr>
-              <td align="left" valign="top" width="54.6%" class="split1">
-                <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td align="center" valign="top"><img src="images/img4.png" width="231" height="184" alt="img2" class="wrap11"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 18px;line-height: 19px;color: #000;font-weight: 700;letter-spacing: -0.1px;">Keynote Speaker: John <br> Randolph, MD, shares findings <br> in most recent study</td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 14px;line-height: 17px;color: #000000;font-weight: 400;letter-spacing: -0.2px;">Vitaqui ius estem. Ovid excepeliqui doluptatem ipis sunt. Ovid  excepeliqui doluptatem ipis experum. Solupta dis imi, utat. Incium idelecum</td>
-                  </tr>
-                </table>
-              </td>
-              <td align="left" valign="top" class="wrap12 split1"><img src="images/img4.png" width="231" height="184" alt="img2"></td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <common-table-spacer-element height="21" />
-    </table>
-  </td>
-</tr>
+<common-content-list-item-block title="Keynote Speaker: John Randolph, MD, shares findings in most recent study" teaser="Vitaqui ius estem. Ovid excepeliqui doluptatem ipis sunt. Ovid  excepeliqui doluptatem ipis experum. Solupta dis imi, utat. Incium idelecum" />
 <!--6th block End -->
 
-<!--7th block start-->
+<!--7th block start-
 <common-ad-emailx-block />
 <!--7th block end-->
 
 <!--8th block start-->
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-      <tr>
-        <td align="center" valign="top">
-          <table width="84%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="20" />
-            <tr>
-              <td  align="left" valign="top" width="54.6%" class="split1">
-                <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td align="center" valign="top"><img src="images/img6.png" width="231" height="185" alt="img6" class="wrap11"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 18px;line-height: 20px;color: #000;font-weight: 700;">Don’t miss the latest in networking</td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 14px;line-height: 17px;color: #000000;text-decoration: underline;font-weight: 400;letter-spacing: -0.2px;">Join the Scavenger hunt <br> Meet the Experts <br> Stay after and Meet the Trialists</td>
-                  </tr>
-                  <common-table-spacer-element height="19" />
-                </table>
-              </td>
-              <td align="left" valign="top" class="wrap12 split1"><img src="images/img6.png" width="231" height="185" alt="img6" ></td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <common-table-spacer-element height="19" />
-    </table>
-  </td>
-</tr>
+<common-content-list-item-block title="Don't miss the latest in networking" teaser="Join the Scavenger hunt, Meet the Experts, Stay after and Meet the Trialists" />
 <!--8th block end-->
 
-<!--9th block start-->
+<!--9th block start
 <common-ad-emailx-block />
 <!--9th block end-->
 
 <!--10th block start-->
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-      <tr>
-        <td align="center" valign="top">
-          <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="17" />
-            <tr>
-              <td  align="left" valign="top" width="54.6%" class="split1">
-                <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td align="center" valign="top"><img src="images/img7.png" width="231" height="185" alt="img6" class="wrap11"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 18px;line-height: 19px;color: #000;font-weight: 700;letter-spacing: 0.2px;">Clinical trial reveals opens door to revolutionary treatments in urology</td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 14px;line-height: 18px;color: #000000;font-weight: 400;letter-spacing: -0.2px;">Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Em earist, officiae et ut exero molut parum exceatur, veror sequamus et mint. <br> Dae volupti num simolec upitata cus <br> dolorum velitatem fugitem et vende comnit aperit utemquam.</td>
-                  </tr>
-                </table>
-              </td>
-              <td align="left" valign="top" class="wrap12 split1"><img src="images/img7.png" width="231" height="185" alt="img6" ></td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <common-table-spacer-element height="15" />
-    </table>
-  </td>
-</tr>
+<common-content-list-item-block title="Clinical trial reveals opens doors to revolutionary treatments in urology" teaser="Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt. Em earist, officiae et ut exero molut parum exceatur, veror sequamus et mint.  Dae volupti num simolec upitata cus  dolorum velitatem fugitem et vende comnit aperit utemquam." />
 <!--10th block end-->
 
-<!--11th block start-->
+<!--11th block start
 <common-ad-emailx-block />
 <!--11th block end-->
 
 <!--12th block start-->
-<tr>
-  <td align="center" valign="top">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-      <tr>
-        <td align="center" valign="top">
-          <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <common-table-spacer-element height="16" />
-            <tr>
-              <td  align="left" valign="top" width="54.6%" class="split1">
-                <table width="100%" border="0"  cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td align="left" valign="top" class="wrap12 split1"><img src="images/img8.png" width="231" height="185" alt="img8" class="wrap11"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 16px;line-height: 20px;color: #000;font-weight: 700;">View moderated posters and more than 600 abstracts in the poster hall</td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="font-size: 15px;line-height: 17px;color: #000000;font-weight: 400;">Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt.<span style="color: #ec8771;font-size: 13px;line-height: 17px;font-weight: 400;">Click here for more info.</span> </td>
-                  </tr>
-                </table>
-              </td>
-              <td align="left" valign="top" class="wrap12 split1"><img src="images/img8.png" width="231" height="185" alt="img8"></td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <common-table-spacer-element height="15" />
-    </table>
-  </td>
-</tr>
+<common-content-list-item-block title="View moderated posters and more than 600 abstracts in the poster hall" teaser="Vitaqui ius estem. Ovid excepeliqui doluptatem ipis experum sunt." withLink=true linkValue="#" linkText="Click here for more info." />
 <!--12th block end-->
 
-<!--13th block start-->
+<!--13th block start
 <common-ad-emailx-block />
 <!--13th block end-->
 
@@ -218,7 +62,7 @@ $ const withSection = defaultValue(input.withSection, true);
 <common-table-spacer-element height="8" />
 <!--14th block end-->
 
-<!--15th block start-->
+<!--15th block start
 <common-ad-emailx-block />
 <!--15th block end-->
 
@@ -256,6 +100,6 @@ $ const withSection = defaultValue(input.withSection, true);
 </tr>
 <!--16th block end-->
 
-<!--17th block start-->
+<!--17th block start
 <common-ad-emailx-block />
 <!--17th block end-->

--- a/packages/common/components/blocks/content/marko.json
+++ b/packages/common/components/blocks/content/marko.json
@@ -1,5 +1,10 @@
 {
   "<common-content-list-item-block>": {
+    "template": "./list-item.marko",
+    "@title": "string",
+    "@teaser": "string"
+  },
+  "<common-content-list-block>": {
     "template": "./list.marko"
   }
 }

--- a/packages/common/components/blocks/content/marko.json
+++ b/packages/common/components/blocks/content/marko.json
@@ -2,7 +2,13 @@
   "<common-content-list-item-block>": {
     "template": "./list-item.marko",
     "@title": "string",
-    "@teaser": "string"
+    "@teaser": "string",
+    "@withLink": "boolean",
+    "@linkValue": "string",
+    "@linkText": "string",
+    "@isAd": "boolean",
+    "@hasLogo": "boolean",
+    "@logoImage": "string"
   },
   "<common-content-list-block>": {
     "template": "./list.marko"

--- a/packages/common/components/blocks/marko.json
+++ b/packages/common/components/blocks/marko.json
@@ -14,5 +14,8 @@
   },
   "<common-footer-block>": {
     "template": "./footer.marko"
+  },
+  "<common-channel-button-block>": {
+    "template": "./channel-button.marko"
   }
 }

--- a/packages/common/components/elements/content-button.marko
+++ b/packages/common/components/elements/content-button.marko
@@ -7,8 +7,8 @@ $ const { content } = input;
         <td align="center" valign="middle" style="height: 48px;">
           $ const buttonLinkStyle = {
             "background-color": "#22919c",
-            "border-radius: 10px",
-            "text-align: center",
+            "border-radius": "10px",
+            "text-align": "center",
             "font-size": "14px",
             "color": "#fff",
             "text-decoration": "none",

--- a/packages/common/components/elements/content-image.marko
+++ b/packages/common/components/elements/content-image.marko
@@ -1,10 +1,9 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-$ const image = {
-  "class": defaultValue(input.class, ""),
-  "align": defaultValue(input.align, "left"),
-  "valign" defaultValue(input.valign, "top"),
-  "width": defaultValue(input.width, "150"),
-  "height": defaultValue(input.height, "130")
-}
+$ const classValue = defaultValue(input.class, "");
+$ const alignValue = defaultValue(input.align, "left");
+$ const valignValue = defaultValue(input.valign, "top");
+$ const widthValue = defaultValue(input.width, "150")
+$ const heightValue = defaultValue(input.height, "130")
 
-<td align=image.align valign=image.valign class=image.class><img src=input.src width=image.width height=image.height alt=input.alt></td>
+
+<td align=alignValue valign=valignValue class=classValue><img src=input.src width=widthValue height=heightValue alt=input.alt></td>

--- a/packages/common/components/elements/content-image.marko
+++ b/packages/common/components/elements/content-image.marko
@@ -2,8 +2,9 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const classValue = defaultValue(input.class, "");
 $ const alignValue = defaultValue(input.align, "left");
 $ const valignValue = defaultValue(input.valign, "top");
-$ const widthValue = defaultValue(input.width, "150")
-$ const heightValue = defaultValue(input.height, "130")
+$ const widthValue = defaultValue(input.width, "150");
+$ const heightValue = defaultValue(input.height, "130");
+$ const classValueTD = defaultValue(input.classValueTD, "");
 
 
-<td align=alignValue valign=valignValue class=classValue><img src=input.src width=widthValue height=heightValue alt=input.alt></td>
+<td align=alignValue valign=valignValue class=classValueTD><img src=input.src width=widthValue height=heightValue alt=input.alt class=classValue></td>

--- a/packages/common/components/elements/marko.json
+++ b/packages/common/components/elements/marko.json
@@ -16,6 +16,7 @@
     "@width": "string",
     "@height": "string",
     "@src": "string",
-    "@alt": "string"
+    "@alt": "string",
+    "@classValueTD": "string"
   }
 }

--- a/packages/common/components/layouts/daily.marko
+++ b/packages/common/components/layouts/daily.marko
@@ -1,11 +1,14 @@
-import { parseBooleanHeader } from "@parameter1/base-cms/utils";
+import { parseBooleanHeader } from "@parameter1/base-cms-utils/src";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date } = input.data;
+$ const { config, req } = out.global;
 
 $ const emailX = config.get("emailX");
 $ const nativeX = config.getAsObject("nativeX");
-$ const adUnits = ["ad-slot-1", "ad-slot-2", "ad-slot-3", "ad-slot-4", "ad-slot-5", "ad-slot-6", "ad-slot-7"];
 
+$ const dayOfWeek = new Date(date).getDay() || 7;
+$ const adUnits = ["ad-slot-1", "ad-slot-2", "ad-slot-3", "ad-slot-4", "ad-slot-5", "ad-slot-6", "ad-slot-7"];
 $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
 
 <marko-newsletter-root
@@ -24,7 +27,7 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           date=date
           section-name="Ad Slot 1"
           newsletter=newsletter
-          ad-unit=emailx.getAdUnit({ name: adSlots[0], alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: adUnits[0], alias: newsletter.alias })
         />
 
         <!-- Content list block (with image) -->
@@ -62,7 +65,7 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           date=date
           section-name="Ad Slot 2"
           newsletter=newsletter
-          ad-unit=emailx.getAdUnit({ name: adSlots[1], alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: adUnits[1], alias: newsletter.alias })
         />
 
         <!-- Content list block (with image) -->
@@ -77,7 +80,7 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           date=date
           section-name="Ad Slot 3"
           newsletter=newsletter
-          ad-unit=emailx.getAdUnit({ name: adSlots[2], alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: adUnits[2], alias: newsletter.alias })
         />
 
         <!-- Content list block (with image) -->
@@ -96,7 +99,7 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           date=date
           section-name="Ad Slot 4"
           newsletter=newsletter
-          ad-unit=emailx.getAdUnit({ name: adSlots[3], alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: adUnits[3], alias: newsletter.alias })
         />
 
         <!-- Content list block (with image) -->
@@ -115,7 +118,7 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           date=date
           section-name="Ad Slot 5"
           newsletter=newsletter
-          ad-unit=emailx.getAdUnit({ name: adSlots[4], alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: adUnits[4], alias: newsletter.alias })
         />
 
         <!-- Content list block (no image) -->
@@ -133,7 +136,7 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           date=date
           section="Ad Slot 6"
           newsletter=newsletter
-          ad-unit=emailx.getAdUnit({ name: adSlots[5], alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: adUnits[5], alias: newsletter.alias })
         />
 
         <!-- Content list block (with image) -->
@@ -152,7 +155,7 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           date=date
           section="Ad Slot 7"
           newsletter=newsletter
-          ad-unit=emailx.getAdUnit({ name: adSlots[6], alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: adUnits[6], alias: newsletter.alias })
         />
       </@body>
     </common-body-wrapper-block>

--- a/packages/common/components/layouts/daily.marko
+++ b/packages/common/components/layouts/daily.marko
@@ -157,8 +157,9 @@ $ const withImage = parseBooleanHeader(get(req, "query.with-image"));
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: adUnits[6], alias: newsletter.alias })
         />
+
+        <common-channel-button-block />
       </@body>
     </common-body-wrapper-block>
-    <common-channel-button-block />
   </@body>
 </marko-newsletter-root>

--- a/packages/common/components/layouts/marko.json
+++ b/packages/common/components/layouts/marko.json
@@ -1,5 +1,6 @@
 {
   "<common-daily-layout>": {
-    "template": "./daily.marko"
+    "template": "./daily.marko",
+    "@data": "object"
   }
 }


### PR DESCRIPTION
I have the barebones layout for both desktop and mobile figured out the only thing I had not tested is how any advertisements (Leaderboards, etc.) would "fit" (I also have yet to test image placements but I might be able to do that and make sure I didn't mess anything up on that front). 

I also looked into if the Ads were wider than the newsletter turns out they are not they are 600x100 and that's the width the content tables fall in between themselves. It would appear on the template we were given they are not representative of the size they will actually occupy once live. 

The top leaderboard in the template should be the size of the rest of them unless I am mistaking or misunderstanding something which is certainly possible.

Do let me know of any questions that come up, I did some partial implementations of the logic for the actual live version but seeing as I currently have no data to connect to on that front it is incomplete until I have a way to figure out all the various object parameters for content, ads, etc.


<img width="1920" alt="Screen Shot 2021-06-11 at 1 44 28 PM" src="https://user-images.githubusercontent.com/46794001/121735556-e8e5c700-cabb-11eb-9e24-715963572741.png">

