### PR TITLE
Correct link text for site, font color for address

### DIFF
--- a/packages/common/components/blocks/body-wrapper.marko
+++ b/packages/common/components/blocks/body-wrapper.marko
@@ -12,7 +12,7 @@ $ const { newsletter, date } = input;
                 <${input.viewOnline} />
               </if>
               <else>
-                <common-view-online-block />
+                <common-view-online-block newsletter=newsletter />
               </else>
 
               <!-- Header block -->

--- a/packages/common/components/blocks/footer.marko
+++ b/packages/common/components/blocks/footer.marko
@@ -95,6 +95,11 @@ $ const taglineStyle = {
             <common-table-spacer-element height="19" />
             <tr>
               <td align="left" valign="top" style=standardStyle>
+                DermWorld Meeting News Central is a publication of the American Academy of Dermatology.
+              </td>
+            </tr>
+            <tr>
+              <td align="left" valign="top" style=standardStyle>
                 Copyright &copy; ${displayYear} American Academy of Dermatology | Association. All rights reserved.
               </td>
             </tr>

--- a/packages/common/components/blocks/head.marko
+++ b/packages/common/components/blocks/head.marko
@@ -1,7 +1,6 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="format-detection" content="telephone=no">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<link href="https://fonts.googleapis.com/css?family=Orbitron:400,500,700,900" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i" rel="stylesheet">
 <style type="text/css">
     /* Outlook link fix */

--- a/packages/common/components/blocks/view-online.marko
+++ b/packages/common/components/blocks/view-online.marko
@@ -1,4 +1,5 @@
 $ const { website } = out.global;
+$ const siteLabel = (input.newsletter.name === 'AAD eNewsletter 1') ? 'AAD Meeting News Central' : website.get("name")
 
 <tr>
   <td align="center" valign="top" >
@@ -7,7 +8,7 @@ $ const { website } = out.global;
         <common-table-spacer-element height="13" />
         <tr>
           <td align="center" valign="middle" style="font-size:15px;line-height:19px; color:#62626c;font-weight:400;">
-            <a href="@{mv_online_version}@" style="text-decoration: none;color: #62626c;">View in browser</a> &nbsp; | &nbsp; <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+            <a href="@{mv_online_version}@" style="text-decoration: none;color: #62626c;">View in browser</a> &nbsp; | &nbsp; <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${siteLabel}</a>
           </td>
         </tr>
         <common-table-spacer-element height="10" />

--- a/tenants/all/config/brands.js
+++ b/tenants/all/config/brands.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     footer: {
       bgColor: '#1c7cd5',
-      address: 'AAD Corporate Offices<br/>9500 W. Bryn Mawr<br/>Rosemont, IL 60018',
+      address: '<p style="color: #ffffff">AAD Corporate Offices<br/>9500 W. Bryn Mawr<br/>Rosemont, IL 60018</p>',
     },
   },
 };


### PR DESCRIPTION

<img width="1792" alt="Screen Shot 2021-06-30 at 9 02 54 AM" src="https://user-images.githubusercontent.com/46794001/123974133-ffc45e80-d981-11eb-93dd-0bab11f02dcc.png">
This also adds additional text to the footer and corrects for the issue of two different fonts being used within the newsletter. (Assumedly)