### PR TITLE
Update to only display “view in browser” for hypertension and vascular templates

### DIFF
--- a/packages/common/components/blocks/body-wrapper.marko
+++ b/packages/common/components/blocks/body-wrapper.marko
@@ -12,7 +12,7 @@ $ const { newsletter, date } = input;
                 <${input.viewOnline} />
               </if>
               <else>
-                <common-view-online-block />
+                <common-view-online-block newsletter=newsletter />
               </else>
 
               <!-- Header block -->

--- a/packages/common/components/blocks/view-online.marko
+++ b/packages/common/components/blocks/view-online.marko
@@ -1,4 +1,10 @@
-$ const { website } = out.global;
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { config, website } = out.global;
+$ const { newsletter } = input;
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const showViewOnline = defaultValue(newsletterConfig.showViewOnline, true);
+$ const showHeaderWebsiteLink = defaultValue(newsletterConfig.showHeaderWebsiteLink, true);
 
 <tr>
   <td align="center" valign="top" >
@@ -7,7 +13,15 @@ $ const { website } = out.global;
         <common-table-spacer-element height="13" />
         <tr>
           <td align="center" valign="middle" style="font-size:15px;line-height:19px; color:#62626c;font-weight:400;">
-            <a href="@{mv_online_version}@" style="text-decoration: none;color: #62626c;">View in browser</a> &nbsp; | &nbsp; <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+            <if(showViewOnline)>
+              <a href="@{mv_online_version}@" style="text-decoration: none;color: #62626c;">View in browser</a>
+            </if>
+            <if(showViewOnline && showHeaderWebsiteLink)>
+              &nbsp; | &nbsp;
+            </if>
+            <if(showHeaderWebsiteLink)>
+              <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+            </if>
           </td>
         </tr>
         <common-table-spacer-element height="10" />

--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -51,6 +51,7 @@ const config = {
   'aha-vascular-discovery-registered-attendees': {
     ...brands.aha,
     name: 'AHA Vascular Discovery Registered Attendees',
+    showHeaderWebsiteLink: false,
     headerImageSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-header.png',
     logoSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-logo-white.png',
     brand: '#VascularDiscovery21',
@@ -65,6 +66,7 @@ const config = {
   'aha-vascular-discovery-non-registered-attendees': {
     ...brands.aha,
     name: 'AHA Vascular Discovery Non-Registered Attendees',
+    showHeaderWebsiteLink: false,
     headerImageSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-header.png',
     logoSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-logo-white.png',
     brand: '#VascularDiscovery21',
@@ -92,6 +94,7 @@ const config = {
   'aha-hypertension-registered': {
     ...brands.aha,
     name: 'AHA Hypertension Registered',
+    showHeaderWebsiteLink: false,
     headerImageSrc: '/files/base/ascend/hh/image/static/aha/aha-hypertension-header.png',
     logoSrc: '/files/base/ascend/hh/image/static/aha/aha-hypertension-logo-white.png',
     brand: '#Hypertension21',
@@ -105,6 +108,7 @@ const config = {
   },
   'aha-hypertension-non-registered': {
     ...brands.aha,
+    showHeaderWebsiteLink: false,
     name: 'AHA Hypertension Non-Registered',
     headerImageSrc: '/files/base/ascend/hh/image/static/aha/aha-hypertension-header.png',
     logoSrc: '/files/base/ascend/hh/image/static/aha/aha-hypertension-logo-white.png',


### PR DESCRIPTION
<img width="690" alt="Screen Shot 2021-09-10 at 10 59 38 AM" src="https://user-images.githubusercontent.com/64623209/132883146-32d0fea2-8651-4cdf-8720-8430ef8302b8.png">
<img width="698" alt="Screen Shot 2021-09-10 at 10 59 57 AM" src="https://user-images.githubusercontent.com/64623209/132883190-7211087c-35d9-4940-a53c-b4a38554aa34.png">

