### PR TITLE
Remove extra “Association” from both footer blocks

### DIFF
--- a/packages/common/components/blocks/footer-aha.marko
+++ b/packages/common/components/blocks/footer-aha.marko
@@ -140,7 +140,7 @@ $ const taglineStyle = {
                 <if(copyright)>
                 <tr>
                   <td align="left" valign="top" style=standardStyle>
-                    Copyright &copy; ${displayYear} $!{copyright} | Association. All rights reserved.
+                    Copyright &copy; ${displayYear} $!{copyright} | All rights reserved.
                   </td>
                 </tr>
                 <common-table-spacer-element height="22" />

--- a/packages/common/components/blocks/footer.marko
+++ b/packages/common/components/blocks/footer.marko
@@ -105,7 +105,7 @@ $ const taglineStyle = {
             <if(copyright)>
             <tr>
               <td align="left" valign="top" style=standardStyle>
-                Copyright &copy; ${displayYear} $!{copyright} | Association. All rights reserved.
+                Copyright &copy; ${displayYear} $!{copyright} | All rights reserved.
               </td>
             </tr>
             <common-table-spacer-element height="22" />


### PR DESCRIPTION
CURRNETLY:
<img width="637" alt="Screen Shot 2021-09-14 at 11 56 16 AM" src="https://user-images.githubusercontent.com/64623209/133301275-ad0c7cdf-9435-4e33-808f-5b2face73865.png">
UPDATE AHA-FOOTER:
<img width="652" alt="Screen Shot 2021-09-14 at 11 56 56 AM" src="https://user-images.githubusercontent.com/64623209/133301292-af4a5843-03bb-44b2-8777-5ed09916ef4f.png">
UPDATE FOOTER:
<img width="631" alt="Screen Shot 2021-09-14 at 11 57 10 AM" src="https://user-images.githubusercontent.com/64623209/133301303-c185ea2d-59d1-487c-bac7-09e741d635e6.png">
