### PR TITLE
Add ‘ePreview’ to description for both aha-vascular templates

### DIFF
--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -51,6 +51,7 @@ const config = {
   'aha-vascular-discovery-registered-attendees': {
     ...brands.aha,
     name: 'AHA Vascular Discovery Registered Attendees',
+    description: 'ePreview',
     showHeaderWebsiteLink: false,
     headerImageSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-header.png',
     logoSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-logo-white.png',
@@ -66,6 +67,7 @@ const config = {
   'aha-vascular-discovery-non-registered-attendees': {
     ...brands.aha,
     name: 'AHA Vascular Discovery Non-Registered Attendees',
+    description: 'ePreview',
     showHeaderWebsiteLink: false,
     headerImageSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-header.png',
     logoSrc: '/files/base/ascend/hh/image/static/aha/aha-vascular-discovery-logo-white.png',


### PR DESCRIPTION
<img width="676" alt="Screen Shot 2021-09-15 at 6 00 15 PM" src="https://user-images.githubusercontent.com/64623209/133524051-24d89215-ae2d-4d97-8f39-db2298fe3711.png">
<img width="676" alt="Screen Shot 2021-09-15 at 6 00 25 PM" src="https://user-images.githubusercontent.com/64623209/133524065-fd7cfe90-ad99-4eee-b7c4-3023eadba987.png">
