### PR TITLE
Update aha-footer logo size

### DIFF
--- a/packages/common/components/elements/logo.marko
+++ b/packages/common/components/elements/logo.marko
@@ -21,6 +21,6 @@ $ const linkStyles = {
   "line-height": "0",
 }
 
-<marko-newsletter-imgix src=logoSrc options={ w: 130 } alt=alt attrs={ border: "0", width: "130", style: logoStyles }>
+<marko-newsletter-imgix src=logoSrc options={ w: 200 } alt=alt attrs={ border: "0", width: "200", style: logoStyles }>
   <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
 </marko-newsletter-imgix>


### PR DESCRIPTION
<img width="703" alt="Screen Shot 2021-09-16 at 8 36 15 AM" src="https://user-images.githubusercontent.com/64623209/133622500-26c90c8d-04f1-43db-9921-8fdc0890c600.png">
<img width="628" alt="Screen Shot 2021-09-16 at 8 34 59 AM" src="https://user-images.githubusercontent.com/64623209/133622510-69bc5839-4601-45b5-af8e-5977851a0f5d.png">
<img width="665" alt="Screen Shot 2021-09-16 at 8 34 49 AM" src="https://user-images.githubusercontent.com/64623209/133622521-fd5947e2-dbec-474e-8126-d0fd59bb89c7.png">
