### PR TITLE
Add font-family to <td> tags

### DIFF
--- a/packages/common/components/blocks/body-wrapper.marko
+++ b/packages/common/components/blocks/body-wrapper.marko
@@ -5,7 +5,7 @@ $ const { newsletter, date } = input;
     <td align="center" valign="top">
       <table role="presentation" width="600" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap000">
         <tr>
-          <td align="center" valign="top">
+          <td align="center" valign="top" style="font-family: 'Roboto', arial, sans-serif">
             <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
               <!-- View online block -->
               <if(input.viewOnline)>

--- a/packages/common/components/blocks/channel-buttons.marko
+++ b/packages/common/components/blocks/channel-buttons.marko
@@ -11,7 +11,7 @@ $ const links = getAsArray(newsletterConfig, "channelButtons.links");
 $ const linkRows = chunkArray(links, 2);
 
 $ const linkAttrs = {
-  style: "font-size: 14px;text-align: center;color: #fff;text-decoration: none;font-weight: 400;",
+  style: "font-family: 'Roboto', arial, sans-serif;font-size: 14px;text-align: center;color: #fff;text-decoration: none;font-weight: 400;",
 };
 
 

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -19,12 +19,14 @@ $ const imgStyles = {
 };
 
 $ const imgLinkStyles = {
+  "font-family": "'Roboto', arial, sans-serif",
   "border": 0,
   "outline": "none",
   "text-decoration": "none",
 };
 
 $ const tagStyle = {
+  "font-family": "'Roboto', arial, sans-serif",
   "font-size": "14px",
   "line-height": "19px",
   "color": "#257478",
@@ -84,7 +86,7 @@ $ const sponsoredTagStyle = {
                   <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
                     <tr>
                       <td align="left" valign="top">
-                        <a style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" class="font1" href=content.siteContext.url>
+                        <a style="font-family: 'Roboto', arial, sans-serif;font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" class="font1" href=content.siteContext.url>
                           ${content.name}
                         </a>
                       </td>
@@ -94,7 +96,7 @@ $ const sponsoredTagStyle = {
                         <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
                           <common-table-spacer-element height="5" />
                           <tr>
-                            <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                            <td align="left" valign="top" style="font-family: 'Roboto', arial, sans-serif;font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
                               ${content.teaser}
                             </td>
                           </tr>
@@ -130,7 +132,7 @@ $ const sponsoredTagStyle = {
             <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
               <common-table-spacer-element height="10" />
               <tr>
-                <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                <td align="left" valign="top" style="font-family: 'Roboto', arial, sans-serif;font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
                   ${content.teaser}
                 </td>
               </tr>
@@ -146,14 +148,14 @@ $ const sponsoredTagStyle = {
       <else>
         <tr>
           <td align="left" valign="top">
-            <a style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" href=content.siteContext.url>
+            <a style="font-family: 'Roboto', arial, sans-serif;font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" href=content.siteContext.url>
               ${content.name}
             </a>
           </td>
         </tr>
         <common-table-spacer-element height="5" />
         <tr>
-          <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+          <td align="left" valign="middle" style="font-family: 'Roboto', arial, sans-serif;font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
             ${content.teaser}
           </td>
         </tr>

--- a/packages/common/components/blocks/head.marko
+++ b/packages/common/components/blocks/head.marko
@@ -2,8 +2,8 @@
 <meta name="format-detection" content="telephone=no">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 <link href="https://fonts.googleapis.com/css?family=Orbitron:400,500,700,900" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i" rel="stylesheet">
 <style type="text/css">
+  @font-face { font-family: Roboto, arial, sans-serif !important; src: url("https://fonts.googleapis.com/css?family=Roboto");}
     /* Outlook link fix */
     #outlook a { padding: 0;}
     /* Hotmail background &amp; line height fixes */

--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -9,6 +9,20 @@ $ const name = (newsletterConfig.name || newsletter.name);
 $ const newsletterDescription = get(newsletterConfig, "description");
 $ const displayDate = moment(date).format("LL");
 
+$ const descriptionStyle = {
+  "font-family": "'Roboto', arial, sans-serif",
+  "font-size": "13px",
+  "font-weight": "bold",
+  "line-height": "13px",
+  "padding": "4px 8px 4px 0",
+  "text-align": "left"
+}
+
+$ const dateStyle = {
+  ...descriptionStyle,
+  "padding": "4px 0 4px 8px",
+  "text-align": "right"
+}
 <tr>
   <td align="center" valign="top">
     <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
@@ -34,7 +48,7 @@ $ const displayDate = moment(date).format("LL");
         <td width="70%" align="left" valign="top">
           <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
-              <td align="left" class="mobile-tagline" style="font-size: 13px;font-weight: bold;line-height: 13px;padding: 4px 8px 4px 0;text-align: left">
+              <td align="left" class="mobile-tagline" style=descriptionStyle>
                 $!{newsletterDescription}
               </td>
             </tr>
@@ -45,7 +59,7 @@ $ const displayDate = moment(date).format("LL");
         <td width="25%" align="right" valign="top">
           <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
-              <td align="right" class="mobile-tagline" style="font-size: 13px;font-weight: bold;line-height: 13px;padding: 4px 0 4px 8px;text-align: right;" valign="middle">
+              <td align="right" class="mobile-tagline" style=dateStyle>
                 ${displayDate}
               </td>
             </tr>

--- a/packages/common/components/blocks/view-online.marko
+++ b/packages/common/components/blocks/view-online.marko
@@ -12,7 +12,7 @@ $ const showHeaderWebsiteLink = defaultValue(newsletterConfig.showHeaderWebsiteL
       <tbody>
         <common-table-spacer-element height="13" />
         <tr>
-          <td align="center" valign="middle" style="font-size:15px;line-height:19px; color:#62626c;font-weight:400;">
+          <td align="center" valign="middle" style="font-family: 'Roboto', arial, sans-serif;font-size:15px;line-height:19px; color:#62626c;font-weight:400;">
             <if(showViewOnline)>
               <a href="@{mv_online_version}@" style="text-decoration: none;color: #62626c;">View in browser</a>
             </if>


### PR DESCRIPTION
Outlook was changing font to Times New Roman instead of following the font family.
<img width="770" alt="Screen Shot 2021-10-04 at 3 22 38 PM" src="https://user-images.githubusercontent.com/64623209/135919572-410349ad-4032-4f5c-bafb-ace0efe5aa66.png">
