### PR TITLE
Change mobile view of footer to hide logo and social icons

### DIFF
--- a/packages/common/components/blocks/footer-aha.marko
+++ b/packages/common/components/blocks/footer-aha.marko
@@ -40,7 +40,7 @@ $ const standardUnderlineStyle = {
       <common-table-spacer-element height="16" />
       <tr>
         <td align="center" valign="top">
-          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
+          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="mobile1">
             <tr>
               <td align="left" valign="top" style=standardStyle>
                 <common-logo-element newsletter=newsletter alt=publicationName />

--- a/packages/common/components/blocks/footer.marko
+++ b/packages/common/components/blocks/footer.marko
@@ -43,7 +43,7 @@ $ const taglineStyle = {
       <common-table-spacer-element height="16" />
       <tr>
         <td align="center" valign="top">
-          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
+          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="mobile1">
             <tr>
               <td align="left" valign="top" style=standardStyle>
                 <common-logo-element newsletter=newsletter alt=publicationName />

--- a/packages/common/components/blocks/footer.marko
+++ b/packages/common/components/blocks/footer.marko
@@ -43,7 +43,7 @@ $ const taglineStyle = {
       <common-table-spacer-element height="16" />
       <tr>
         <td align="center" valign="top">
-          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="mobile1">
+          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
             <tr>
               <td align="left" valign="top" style=standardStyle>
                 <common-logo-element newsletter=newsletter alt=publicationName />


### PR DESCRIPTION
aha-footer:
<img width="567" alt="Screen Shot 2021-11-01 at 1 28 40 PM" src="https://user-images.githubusercontent.com/64623209/139722517-f619cc70-061d-4ab1-b470-6b1ae4854318.png">
standard footer:
<img width="551" alt="Screen Shot 2021-11-01 at 1 30 11 PM" src="https://user-images.githubusercontent.com/64623209/139722550-30127d91-3751-41c7-a683-2b3c84e930d2.png">
