### PR TITLE
Update aha-footer to stack social icons and brand on mobile

### DIFF
--- a/packages/common/components/blocks/footer-aha.marko
+++ b/packages/common/components/blocks/footer-aha.marko
@@ -40,7 +40,7 @@ $ const standardUnderlineStyle = {
       <common-table-spacer-element height="16" />
       <tr>
         <td align="center" valign="top">
-          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="mobile1">
+          <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
             <tr>
               <td align="left" valign="top" style=standardStyle>
                 <common-logo-element newsletter=newsletter alt=publicationName />
@@ -49,7 +49,7 @@ $ const standardUnderlineStyle = {
               $ const socialMedia = get(newsletterConfig, "socialMedia");
               $ const socialMediaLinks = getAsArray(socialMedia, "links");
 
-              <td align="center" valign="top" style=standardStyle>
+              <td align="center" valign="top" style=standardStyle class="stack">
                 <if(socialMediaLinks.length)>
                   <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0">
                     <tr>
@@ -69,7 +69,7 @@ $ const standardUnderlineStyle = {
                   </table>
                 </if>
               </td>
-              <td align="right" valign="top" style=brandStyle>
+              <td align="right" valign="top" style=brandStyle class="stack">
                 ${brand}
               </td>
             </tr>

--- a/packages/common/components/blocks/footer-aha.marko
+++ b/packages/common/components/blocks/footer-aha.marko
@@ -42,7 +42,7 @@ $ const standardUnderlineStyle = {
         <td align="center" valign="top">
           <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="left" valign="top" style=standardStyle>
+              <td align="left" valign="top" style=standardStyle class="stack">
                 <common-logo-element newsletter=newsletter alt=publicationName />
               </td>
 

--- a/packages/common/components/blocks/head.marko
+++ b/packages/common/components/blocks/head.marko
@@ -31,6 +31,7 @@
       .split-hide{display: none !important;}
     }
   @media screen and (max-width: 479px) {
+    .stack{display: block !important;clear: both !important;padding: 10px 20px 0px 0px !important;}
     .wdt{width: 180px !important;}
     .mobile{display: block !important;}
     .mobile1{display: none!important;}

--- a/packages/common/components/blocks/head.marko
+++ b/packages/common/components/blocks/head.marko
@@ -31,7 +31,7 @@
       .split-hide{display: none !important;}
     }
   @media screen and (max-width: 479px) {
-    .stack{display: block !important;clear: both !important;padding: 10px 20px 0px 0px !important;}
+    .stack{display: block !important;clear: both !important;text-align: center !important;padding: 0 0 20px 0 !important;}
     .wdt{width: 180px !important;}
     .mobile{display: block !important;}
     .mobile1{display: none!important;}


### PR DESCRIPTION
<img width="363" alt="Screen Shot 2021-11-02 at 1 01 40 PM" src="https://user-images.githubusercontent.com/64623209/139920633-01814f15-65f8-4c61-9303-843588fbcc55.png">
