### PR TITLE
Create new larger layout (expand to 650px)

### DIFF
--- a/packages/common/components/blocks/content/large-list-item.marko
+++ b/packages/common/components/blocks/content/large-list-item.marko
@@ -1,0 +1,124 @@
+import { get, getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { URLSearchParams } from "url";
+
+$ const { content, urlParams, ctaLinkStyle } = input;
+
+$ const withImage = defaultValue(input.withImage, true);
+$ const imagePosition = defaultValue(input.imagePosition, 'right');
+$ const withSection = defaultValue(input.withSection, false);
+$ const continueReading = defaultValue(input.continueReading, false);
+
+$ const imgStyles = {
+  "border": 0,
+  "outline": "none",
+  "text-decoration": "none",
+  "display": "block",
+  "height": "auto !important",
+  "max-width": "100% !important",
+};
+
+$ const imgLinkStyles = {
+  "font-family": "'Roboto', arial, sans-serif",
+  "border": 0,
+  "outline": "none",
+  "text-decoration": "none",
+};
+
+$ const tagStyle = {
+  "font-family": "'Roboto', arial, sans-serif",
+  "font-size": "14px",
+  "line-height": "19px",
+  "color": "#257478",
+  "text-transform": "uppercase",
+}
+
+$ const sponsoredTagStyle = {
+  ...tagStyle,
+  "color": "#a91b20",
+}
+
+<tr>
+  <td align="center" valign="top">
+    <table role="presentation" width="650" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
+
+      $ const labels = getAsArray(content, "labels");
+      <if(labels.includes("Sponsored"))>
+        $ const tag = (content.company) ? `Sponsored Content by ${get(content, "company.name")}` : "Sponsored Content";
+        <tr>
+          <td align="left" valign="top" style=sponsoredTagStyle>${tag}</td>
+        </tr>
+      </if>
+      <else-if(withSection)>
+        <tr>
+          <td align="left" valign="top" style=tagStyle>${get(content, "primarySection.name")}</td>
+        </tr>
+      </else-if>
+
+      <common-table-spacer-element height="6" />
+        <tr>
+          <td align="left" valign="top">
+            <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
+              <tr>
+                <td align="left" valign="top">
+                  <a style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" class="font1" href=content.siteContext.url>
+                    ${content.name}
+                  </a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      <common-table-spacer-element height="6" />
+
+        <tr>
+          <td align="center" valign="top">
+            <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
+              <marko-newsletter-imgix
+                src=image.src
+                alt=image.alt
+                options={ w: 1300, h: 650, fit: "crop", auto: "format,compress" }
+                class="img_resize1"
+                attrs={ border: 0, width: 650, align: "center", vspace: 5, style: imgStyles }
+              >
+                <@link href=content.siteContext.url target="_blank" attrs={ style: imgLinkStyles } />
+              </marko-newsletter-imgix>
+            </marko-core-obj-value>
+          </td>
+        </tr>
+        <common-table-spacer-element height="10" />
+        <tr>
+          <td align="center" valign="top" dir="ltr">
+            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td align="left" valign="top">
+                  <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
+                    <tr>
+                      <td>
+                        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
+                          <common-table-spacer-element height="5" />
+                          <tr>
+                            <td align="left" valign="top">
+                              <a style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;text-decoration: none;" href=content.siteContext.url>
+                                ${content.teaser}
+                              </a>
+                            </td>
+                          </tr>
+                          <if(content.type === 'promotion')>
+                            <common-table-spacer-element height="9" />
+                            $ const linkText = content.linkText || undefined;
+                            <common-cta-element link-style=ctaLinkStyle link-text=linkText link-url=content.siteContext.url />
+                          </if>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      <common-table-spacer-element height="32" />
+    </table>
+  </td>
+</tr>

--- a/packages/common/components/blocks/content/large-list.marko
+++ b/packages/common/components/blocks/content/large-list.marko
@@ -1,0 +1,44 @@
+import { get, getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import queryFragment from "@ascend-media/package-common/graphql/fragments/content-list";
+
+$ const { config } = out.global;
+
+$ const { sectionName, date, newsletter } = input;
+
+$ const withImage = defaultValue(input.withImage, true);
+$ const imagePosition = defaultValue(input.imagePosition, 'right');
+$ const withHeader = defaultValue(input.withHeader, false);
+$ const withSection = defaultValue(input.withSection, false);
+$ const continueReading = defaultValue(input.continueReading, false);
+
+$ const newsletterConfig = config.get(newsletter.alias);
+
+$ const ctaLinkStyle = defaultValue(newsletterConfig.ctaLinkStyle, undefined);
+
+$ const queryParams = {
+  date: date.valueOf(),
+  newsletterId: newsletter.id,
+  sectionName,
+  limit: input.limit || 3,
+  skip: input.skip || 0,
+  queryFragment,
+};
+
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
+  <if(nodes.length)>
+    <if(withHeader)>
+      <common-list-header-element title=sectionName />
+    </if>
+    <for|content| of=nodes>
+      <common-content-large-list-item-block
+        content=content
+        with-section=withSection
+        with-image=withImage
+        image-position=imagePosition
+        continue-reading=continueReading
+        cta-link-style=ctaLinkStyle
+      />
+    </for>
+  </if>
+</marko-web-query>

--- a/packages/common/components/blocks/content/marko.json
+++ b/packages/common/components/blocks/content/marko.json
@@ -7,5 +7,11 @@
   },
   "<common-content-list-item-block>": {
     "template": "./list-item.marko"
+  },
+  "<common-content-large-list-block>": {
+    "template": "./large-list.marko"
+  },
+  "<common-content-large-list-item-block>": {
+    "template": "./large-list-item.marko"
   }
 }

--- a/packages/common/components/blocks/large-body-wrapper.marko
+++ b/packages/common/components/blocks/large-body-wrapper.marko
@@ -1,0 +1,43 @@
+$ const { newsletter, date } = input;
+
+<table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr>
+    <td align="center" valign="top">
+      <table role="presentation" width="650" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap000">
+        <tr>
+          <td align="center" valign="top" style="font-family: 'Roboto', arial, sans-serif">
+            <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+              <!-- View online block -->
+              <if(input.viewOnline)>
+                <${input.viewOnline} />
+              </if>
+              <else>
+                <common-view-online-block newsletter=newsletter />
+              </else>
+
+              <!-- Header block -->
+              <if(input.header)>
+                <${input.header} />
+              </if>
+              <else>
+                <common-header-block date=date newsletter=newsletter />
+              </else>
+
+              <if(input.body)>
+                <${input.body} />
+              </if>
+
+              <!-- Footer block -->
+              <if(input.footer)>
+                <${input.footer} />
+              </if>
+              <else>
+                <common-footer-block date=date newsletter=newsletter />
+              </else>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/packages/common/components/blocks/marko.json
+++ b/packages/common/components/blocks/marko.json
@@ -23,5 +23,8 @@
   },
   "<common-footer-aha-block>": {
     "template": "./footer-aha.marko"
+  },
+  "<common-large-body-wrapper-block>": {
+    "template": "./large-body-wrapper.marko"
   }
 }

--- a/packages/common/components/layouts/large-standard.marko
+++ b/packages/common/components/layouts/large-standard.marko
@@ -1,0 +1,158 @@
+import { get } from "@parameter1/base-cms-object-path";
+import { parseBooleanHeader } from "@parameter1/base-cms-utils";
+import queryFragment from "@ascend-media/package-common/graphql/fragments/content-list";
+
+$ const { website, config, req } = out.global;
+$ const { newsletter, date } = input.data;
+
+$ const emailX = config.get("emailX");
+$ const nativeX = config.getAsObject("nativeX");
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-head-block />
+  </@head>
+  <@body style="padding:0; margin:0;font-family: 'Roboto', Arial, sans-serif; -webkit-text-size-adjust:100%;">
+    <common-large-body-wrapper-block newsletter=newsletter date=date footer=input.footer>
+      <@body>
+
+        <!-- Ad Slot 1 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-1', alias: newsletter.alias })
+          date=date
+        />
+
+        <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=0
+        />
+
+        <!-- Advertisement / Promotion block -->
+        <common-ad-wrapper-block
+          date=date
+          newsletter=newsletter
+          promotion-component="advertisement-block"
+          placement-id=get(nativeX, `placements.${newsletter.alias}.native-slot-1`)
+        />
+
+        <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=1
+        />
+
+        <!-- Ad Slot 2 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-2', alias: newsletter.alias })
+          date=date
+        />
+
+        <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=2
+        />
+
+        <!-- Ad Slot 3 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
+          date=date
+        />
+
+        <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=3
+        />
+
+        <!-- Ad Slot 4 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
+          date=date
+        />
+
+        <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=4
+        />
+
+        <!-- Ad Slot 5 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-5', alias: newsletter.alias })
+          date=date
+        />
+
+        <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=5
+        />
+
+        <!-- Ad Slot 6 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-6', alias: newsletter.alias })
+          date=date
+        />
+
+        <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=6
+        />
+
+        <!-- Ad Slot 7 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-7', alias: newsletter.alias })
+          date=date
+        />
+
+         <!-- Content list block -->
+        <common-content-large-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=3
+          skip=7
+        />
+
+        <!-- Channels -->
+        <common-channel-buttons-block newsletter=newsletter />
+
+      </@body>
+    </common-large-body-wrapper-block>
+  </@body>
+</marko-newsletter-root>

--- a/packages/common/components/layouts/marko.json
+++ b/packages/common/components/layouts/marko.json
@@ -1,5 +1,8 @@
 {
   "<common-standard-layout>": {
     "template": "./standard.marko"
+  },
+  "<common-large-standard-layout>": {
+    "template": "./large-standard.marko"
   }
 }


### PR DESCRIPTION
Reorder layout to have content title on top then primary image with teaser under image.
![screencapture-localhost-22290-templates-aad-enewsletter-1-2021-11-08-13_07_48](https://user-images.githubusercontent.com/64623209/140803411-6cf6aa4e-254e-4e29-8ccc-541d434c337c.png)
