### PR TITLE
Remove advertiserName from link labels

### DIFF
--- a/packages/common/components/blocks/ad/emailx.marko
+++ b/packages/common/components/blocks/ad/emailx.marko
@@ -44,7 +44,7 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
                     ...input.link
                     href=href
                     attrs={
-                      linklabel: `ad|${adLocation}|${platformDesignator}|${ad.advertiserName}|${ad.lineitemName}`
+                      linklabel: `ad|${adLocation}|${platformDesignator}|${ad.lineitemName}`
                     }
                   />
                 </marko-core-img>


### PR DESCRIPTION
<img width="1725" alt="Screen Shot 2022-05-11 at 7 59 56 AM" src="https://user-images.githubusercontent.com/64623209/167857382-266b6d8d-1a3a-4fe3-9173-10f99a099429.png">
<img width="1792" alt="Screen Shot 2022-05-11 at 8 02 52 AM" src="https://user-images.githubusercontent.com/64623209/167857387-2572af1d-0679-4e89-b6d4-87ce043dc2a1.png">


