### PR TITLE
Add ```customWebsiteLinkText``` to ASA core config

### DIFF
--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -296,6 +296,7 @@ const config = {
     logoSrc: '/files/base/ascend/hh/image/static/asa/asa-footer-logo.png',
     headerImageSrc: '/files/base/ascend/hh/image/static/asa/amdn-22.jpeg',
     name: 'Annual Meeting Daily News',
+    customWebsiteLinkText: 'Annual Meeting Daily News',
     description: 'eDaily',
     ctaLinkStyle: {
       color: '#8a84d6',


### PR DESCRIPTION
This changes the text next to ‘View Online’ 
<img width="688" alt="Screen Shot 2022-07-11 at 11 47 30 AM" src="https://user-images.githubusercontent.com/64623209/178316236-5912783e-0ab2-4b8f-bc5a-cd5992f35d41.png">
