### PR TITLE
remove ‘input’ from ACEP templates-only pass data

### DIFF
--- a/tenants/all/templates/acep-enewsletter-2.marko
+++ b/tenants/all/templates/acep-enewsletter-2.marko
@@ -4,7 +4,7 @@ import queryFragment from "@ascend-media/package-common/graphql/fragments/conten
 
 $ const { website, config, req } = out.global;
 $ const platformDesignator = 'd';
-$ const { newsletter, date } = input.data;
+$ const { newsletter, date } = data;
 
 $ const emailX = config.get("emailX");
 $ const nativeX = config.getAsObject("nativeX");

--- a/tenants/all/templates/acep-enewsletter.marko
+++ b/tenants/all/templates/acep-enewsletter.marko
@@ -4,7 +4,7 @@ import queryFragment from "@ascend-media/package-common/graphql/fragments/conten
 
 $ const { website, config, req } = out.global;
 $ const platformDesignator = 'd';
-$ const { newsletter, date } = input.data;
+$ const { newsletter, date } = data;
 
 $ const emailX = config.get("emailX");
 $ const nativeX = config.getAsObject("nativeX");


### PR DESCRIPTION
Newsletter templates load:
<img width="813" alt="Screen Shot 2022-09-14 at 7 07 16 AM" src="https://user-images.githubusercontent.com/64623209/190149397-ce916901-440d-47e0-8015-d0dc875bb360.png">
