### PR TITLE
Revert link-label changes for Email-X ads only

### DIFF
--- a/packages/common/components/blocks/ad/emailx.marko
+++ b/packages/common/components/blocks/ad/emailx.marko
@@ -44,7 +44,7 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
                     ...input.link
                     href=href
                     attrs={
-                      linklabel: `ad|${adLocation}|${platformDesignator}|%prjname%|${ad.advertiserName}|%blastname%|Traffic Driving Ad|${ad.lineitemName}`
+                      linklabel: `ad|${adLocation}|${platformDesignator}|${ad.lineitemName}`
                     }
                   />
                 </marko-core-img>


### PR DESCRIPTION
PROD EmailX ad:
<img width="1789" alt="Screen Shot 2023-05-02 at 1 54 31 PM" src="https://user-images.githubusercontent.com/64623209/235759808-8edc9093-1a49-45bd-b805-74bb2c0122ae.png">
DEV EmailX ad:
<img width="1744" alt="Screen Shot 2023-05-02 at 1 42 59 PM" src="https://user-images.githubusercontent.com/64623209/235760226-43bbb7b9-5928-4af2-9369-013c2df61bd6.png">

PROD NativeX ad:
<img width="1788" alt="Screen Shot 2023-05-02 at 1 54 20 PM" src="https://user-images.githubusercontent.com/64623209/235759993-75777891-47f8-4619-874a-a510c8b88dca.png">
DEV NativeX ad:
<img width="1778" alt="Screen Shot 2023-05-02 at 1 54 11 PM" src="https://user-images.githubusercontent.com/64623209/235760118-d8b5e758-0f7e-4f58-871b-805569dd9ee0.png">
