### PR TITLE
Remove ASA Today newsletter & ad units

### DIFF
--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -183,18 +183,6 @@ const config = {
       ],
     },
   },
-  'asa-today': {
-    ...brands.asa,
-    name: 'Anesthesiology Today, Annual Meeting Edition',
-    description: 'eDaily',
-    channelButtons: {
-      bgColor: '#8a84d6',
-      links: [
-        { label: 'Registration', href: 'https://www.asahq.org/annualmeeting/attend/registration', target: '_blank' },
-        { label: 'Program', href: 'https://www.abstractsonline.com/pp8/#!/9323', target: '_blank' },
-      ],
-    },
-  },
   'aha-ss-international': {
     ...brands.aha,
     name: 'AHA Scientific Sessions ePreview',

--- a/tenants/all/config/email-x.js
+++ b/tenants/all/config/email-x.js
@@ -693,50 +693,6 @@ config
       height: 250,
     },
   ])
-  .setAdUnits('asa-today', [
-    {
-      name: 'ad-slot-1',
-      id: '612e6e496a853cc33de6eeba',
-      width: 600,
-      height: 100,
-    },
-    {
-      name: 'ad-slot-2',
-      id: '612e6e5a6a853c2e03e6eecd',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'ad-slot-3',
-      id: '612e6e6d9006f62ec55cb3ec',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'ad-slot-4',
-      id: '612e6e806a853ce0f2e6eee0',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'ad-slot-5',
-      id: '612e6e906a853c3398e6eef3',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'ad-slot-6',
-      id: '612e6ea26a853c4c2ee6ef06',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'ad-slot-7',
-      id: '612e6eb19006f665a95cb423',
-      width: 600,
-      height: 100,
-    },
-  ])
   .setAdUnits('aha-ss-international', [
     {
       name: 'ad-slot-1',

--- a/tenants/all/config/native-x.js
+++ b/tenants/all/config/native-x.js
@@ -37,9 +37,6 @@ module.exports = {
     'aao-hnsf': {
       'native-slot-1': '611ebab3b4c21e0001a3c13a',
     },
-    'asa-today': {
-      'native-slot-1': '612e6df8fb61160001598bd5',
-    },
     'aha-ss-international': {
       'native-slot-1': '616d87f41ff6d3000117db14',
     },

--- a/tenants/all/templates/asa-today.marko
+++ b/tenants/all/templates/asa-today.marko
@@ -1,1 +1,0 @@
-<common-standard-layout data=data />


### PR DESCRIPTION
Shows ASA Today 2022 was renamed to ASA Today

<img width="695" alt="Screen Shot 2023-09-14 at 11 10 59 AM" src="https://github.com/parameter1/ascend-media-newsletters/assets/64623209/c8e1e9cd-553d-476c-996e-dcf14c625434">
