### PR TITLE
Adjust ampulmonary layout

### DIFF
--- a/packages/common/components/layouts/am-standard.marko
+++ b/packages/common/components/layouts/am-standard.marko
@@ -51,7 +51,7 @@ $ const nativeX = config.getAsObject("nativeX");
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          limit=1
+          limit=2
           skip=2
           storyLocation=3
         />
@@ -69,8 +69,8 @@ $ const nativeX = config.getAsObject("nativeX");
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          limit=1
-          skip=3
+          limit=2
+          skip=4
           storyLocation=4
         />
 
@@ -87,8 +87,8 @@ $ const nativeX = config.getAsObject("nativeX");
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          limit=1
-          skip=4
+          limit=2
+          skip=6
           storyLocation=5
         />
 
@@ -105,8 +105,8 @@ $ const nativeX = config.getAsObject("nativeX");
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          limit=1
-          skip=5
+          limit=2
+          skip=8
           storyLocation=6
         />
 
@@ -124,7 +124,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           with-image=false
           limit=7
-          skip=6
+          skip=10
           storyLocation=7
         />
 


### PR DESCRIPTION
wants to have 2 articles between native ads
<img width="422" alt="Screen Shot 2023-10-30 at 7 26 33 AM" src="https://github.com/parameter1/ascend-media-newsletters/assets/64623209/5d1e9912-1159-43a0-8e12-315eec307f11">
