### PR TITLE
Add article block to AAD Exhibitor Spotlight template

### DIFF
--- a/tenants/all/templates/aad-exhibitor-spotlight.marko
+++ b/tenants/all/templates/aad-exhibitor-spotlight.marko
@@ -20,6 +20,16 @@ $ const nativeX = config.getAsObject("nativeX");
     <common-body-wrapper-block newsletter=newsletter date=date footer=input.footer>
       <@body>
 
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          limit=1
+          skip=0
+          storyLocation=1
+        />
+
         <!-- Advertisement / Promotion block -->
         <common-ad-wrapper-block
           date=date


### PR DESCRIPTION
<img width="811" alt="Screen Shot 2024-01-30 at 7 17 11 AM" src="https://github.com/parameter1/ascend-media-newsletters/assets/64623209/0bfb05d1-c669-4bcd-b8c0-596b4e000864">
