### PR TITLE
Remove Ascend's address from Aesthetics footer

### DIFF
--- a/packages/common/components/blocks/footer.marko
+++ b/packages/common/components/blocks/footer.marko
@@ -17,7 +17,7 @@ $ const address = get(newsletterConfig, "footer.address") || "";
 $ const copyright = get(newsletterConfig, "footer.copyright") || "";
 $ const unsubscribe = get(newsletterConfig, "footer.unsubscribe");
 $ const vendorTagline = get(newsletterConfig, "footer.vendorTagline");
-$ const ascendAddress = get(newsletterConfig, "footer.ascendAddress") || "";
+$ const ascendAddress = get(newsletterConfig, "ascendAddress") || "";
 $ const twitterTag = get(newsletterConfig, "footer.twitterTag");
 $ const SHMaddress = defaultValue(newsletterConfig.footer.SHMaddress, false);
 

--- a/tenants/all/config/brands.js
+++ b/tenants/all/config/brands.js
@@ -18,7 +18,6 @@ module.exports = {
       copyright: 'American Academy of Dermatology | Association',
       unsubscribe: 'If you no longer wish to receive industry promotional emails for the 2024 AAD Annual Meeting, ',
       vendorTagline: 'Ascend Media is an official advertising vendor for the AAD.',
-      ascendAddress: 'Ascend Media | 401 SW Ward Rd, Suite 210, Lee\'s Summit, MO 64083, United States',
     },
   },
   aua: {

--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -23,6 +23,7 @@ const config = {
         { label: 'Registration', href: 'https://www.aad.org/member/meetings-education/am24/registration', target: '_blank' },
       ],
     },
+    ascendAddress: 'Ascend Media | 401 SW Ward Rd, Suite 210, Lee\'s Summit, MO 64083, United States',
   },
   'aua-daily-domestic': {
     ...brands.aua,
@@ -49,6 +50,7 @@ const config = {
         { label: 'Registration', href: 'https://www.aad.org/member/meetings-education/am24/registration', target: '_blank' },
       ],
     },
+    ascendAddress: 'Ascend Media | 401 SW Ward Rd, Suite 210, Lee\'s Summit, MO 64083, United States',
   },
   'aha-vascular-discovery-registered-attendees': {
     ...brands.aha,
@@ -271,6 +273,7 @@ const config = {
         { label: 'Registration', href: 'https://www.aad.org/member/meetings-education/am24/registration', target: '_blank' },
       ],
     },
+    ascendAddress: 'Ascend Media | 401 SW Ward Rd, Suite 210, Lee\'s Summit, MO 64083, United States',
   },
   'aua-daily-international': {
     ...brands.aua,
@@ -370,6 +373,7 @@ const config = {
         { label: 'Registration', href: 'https://www.aad.org/member/meetings-education/am24/registration', target: '_blank' },
       ],
     },
+    ascendAddress: 'Ascend Media | 401 SW Ward Rd, Suite 210, Lee\'s Summit, MO 64083, United States',
   },
   'shm-enewsletter-2': {
     ...brands.shm,
@@ -407,6 +411,7 @@ const config = {
         { label: 'About the Meeting', href: 'https://www.aad.org/member/meetings-education/am24', target: '_blank' },
       ],
     },
+    ascendAddress: 'Ascend Media | 401 SW Ward Rd, Suite 210, Lee\'s Summit, MO 64083, United States',
   },
   'aad-exhibitor-spotlight': {
     ...brands.aad,
@@ -419,6 +424,7 @@ const config = {
         { label: 'Registration', href: 'https://www.aad.org/member/meetings-education/am24/registration', target: '_blank' },
       ],
     },
+    ascendAddress: 'Ascend Media | 401 SW Ward Rd, Suite 210, Lee\'s Summit, MO 64083, United States',
   },
   'aad-aesthetics': {
     ...brands.aad,


### PR DESCRIPTION
Aesthetics:
<img width="1087" alt="Screenshot 2024-04-15 at 1 25 56 PM" src="https://github.com/parameter1/ascend-media-newsletters/assets/64623209/d40befbf-ebf0-45ec-aca9-c5135039283f">

other AAD newsletters still display address under footer:
<img width="1089" alt="Screenshot 2024-04-15 at 1 27 09 PM" src="https://github.com/parameter1/ascend-media-newsletters/assets/64623209/109ca9d1-2316-4ff7-b5ce-af8dc4872bb4">
