### PR TITLE
Correctly import `getAsObject` within `common-content-list-item-block`

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -49,7 +49,7 @@ $ const linkAttrs = {
 };
 
 $ const imgLinkAttrs = { style: imgLinkStyles, linklabel: linkLabel, ...linkAttrs };
-$ const nameLinkAttrs = { style: {}, ...linkAttrs };
+$ const nameLinkAttrs = linkAttrs;
 
 <tr>
   <td align="center" valign="top">

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -1,4 +1,4 @@
-import { get, getAsArray } from "@parameter1/base-cms-object-path";
+import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { URLSearchParams } from "url";
 
@@ -49,7 +49,7 @@ $ const linkAttrs = {
 };
 
 $ const imgLinkAttrs = { style: imgLinkStyles, linklabel: linkLabel, ...linkAttrs };
-$ const nameLinkAttrs = { style: nameLinkStyles, ...linkAttrs };
+$ const nameLinkAttrs = { style: {}, ...linkAttrs };
 
 <tr>
   <td align="center" valign="top">


### PR DESCRIPTION
This was missed via https://github.com/parameter1/ascend-media-newsletters/commit/3f7def30fdd05b5a9db1269ebe5623214d066931 as part of https://github.com/parameter1/ascend-media-newsletters/pull/183

`getAsObject` was not appropriately imported in this file when it was added causing newsletters utilizing this component to error and not render their content as shown below:

PRODUCTION:
![image](https://github.com/parameter1/ascend-media-newsletters/assets/46794001/436c91b1-9196-4536-bb08-9377b0084fb3)

DEVELOPMENT:
![image](https://github.com/parameter1/ascend-media-newsletters/assets/46794001/ff137810-926b-412d-9714-169d6a5f9a8d)

