### PR TITLE
Link to `/aesthetics` in Aesthetics newsletters

### DIFF
--- a/packages/common/components/blocks/view-online.marko
+++ b/packages/common/components/blocks/view-online.marko
@@ -7,8 +7,6 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const customWebsiteLinkText = get(newsletterConfig, "customWebsiteLinkText");
 $ const showViewOnline = defaultValue(newsletterConfig.showViewOnline, true);
 $ const showHeaderWebsiteLink = defaultValue(newsletterConfig.showHeaderWebsiteLink, true);
-$ const customWebsite = get(newsletterConfig, "customWebsite");
-$ const useCustomWebsite = defaultValue(newsletterConfig.useCustomWebsite, false);
 
 <tr>
   <td align="center" valign="top" >
@@ -20,23 +18,15 @@ $ const useCustomWebsite = defaultValue(newsletterConfig.useCustomWebsite, false
             <if(showViewOnline)>
               <a href="@{mv_online_version}@" style="text-decoration: none;color: #62626c;">View in browser</a>
             </if>
-            <if(showViewOnline && useCustomWebsite)>
+            <if(showViewOnline && showHeaderWebsiteLink)>
               &nbsp; | &nbsp;
-              <if(customWebsite)>
-                <a href=`${customWebsite}` style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+              <if(customWebsiteLinkText)>
+                <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${customWebsiteLinkText}</a>
               </if>
+              <else>
+                <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+              </else>
             </if>
-            <else>
-              <if(showViewOnline && showHeaderWebsiteLink)>
-                &nbsp; | &nbsp;
-                <if(customWebsiteLinkText)>
-                  <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${customWebsiteLinkText}</a>
-                </if>
-                <else>
-                  <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
-                </else>
-              </if>
-            </else>
           </td>
         </tr>
         <common-table-spacer-element height="10" />

--- a/packages/common/components/blocks/view-online.marko
+++ b/packages/common/components/blocks/view-online.marko
@@ -7,6 +7,8 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const customWebsiteLinkText = get(newsletterConfig, "customWebsiteLinkText");
 $ const showViewOnline = defaultValue(newsletterConfig.showViewOnline, true);
 $ const showHeaderWebsiteLink = defaultValue(newsletterConfig.showHeaderWebsiteLink, true);
+$ const customWebsite = get(newsletterConfig, "customWebsite");
+$ const useCustomWebsite = defaultValue(newsletterConfig.useCustomWebsite, false);
 
 <tr>
   <td align="center" valign="top" >
@@ -18,15 +20,23 @@ $ const showHeaderWebsiteLink = defaultValue(newsletterConfig.showHeaderWebsiteL
             <if(showViewOnline)>
               <a href="@{mv_online_version}@" style="text-decoration: none;color: #62626c;">View in browser</a>
             </if>
-            <if(showViewOnline && showHeaderWebsiteLink)>
+            <if(showViewOnline && useCustomWebsite)>
               &nbsp; | &nbsp;
-              <if(customWebsiteLinkText)>
-                <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${customWebsiteLinkText}</a>
+              <if(customWebsite)>
+                <a href=`${customWebsite}` style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
               </if>
-              <else>
-                <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
-              </else>
             </if>
+            <else>
+              <if(showViewOnline && showHeaderWebsiteLink)>
+                &nbsp; | &nbsp;
+                <if(customWebsiteLinkText)>
+                  <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${customWebsiteLinkText}</a>
+                </if>
+                <else>
+                  <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+                </else>
+              </if>
+            </else>
           </td>
         </tr>
         <common-table-spacer-element height="10" />

--- a/packages/common/components/blocks/view-online.marko
+++ b/packages/common/components/blocks/view-online.marko
@@ -7,6 +7,10 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const customWebsiteLinkText = get(newsletterConfig, "customWebsiteLinkText");
 $ const showViewOnline = defaultValue(newsletterConfig.showViewOnline, true);
 $ const showHeaderWebsiteLink = defaultValue(newsletterConfig.showHeaderWebsiteLink, true);
+$ const newsletterNameToSiteOriginMap = {
+  "aad-aesthetics": "https://www.aadmeetingnews.org/aesthetics"
+};
+$ const origin = newsletterNameToSiteOriginMap[newsletter.alias] || website.get("origin");
 
 <tr>
   <td align="center" valign="top" >
@@ -21,10 +25,10 @@ $ const showHeaderWebsiteLink = defaultValue(newsletterConfig.showHeaderWebsiteL
             <if(showViewOnline && showHeaderWebsiteLink)>
               &nbsp; | &nbsp;
               <if(customWebsiteLinkText)>
-                <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${customWebsiteLinkText}</a>
+                <a href=origin style="text-decoration: none;color: #62626c;">${customWebsiteLinkText}</a>
               </if>
               <else>
-                <a href=website.get("origin") style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+                <a href=origin style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
               </else>
             </if>
           </td>

--- a/packages/common/components/elements/logo.marko
+++ b/packages/common/components/elements/logo.marko
@@ -9,6 +9,11 @@ $ const logoSrc = newsletterConfig.logoSrc;
 
 $ const alt = defaultValue(input.alt, newsletter.name);
 
+$ const newsletterNameToSiteOriginMap = {
+  "aad-aesthetics": "https://www.aadmeetingnews.org/aesthetics"
+};
+$ const origin = newsletterNameToSiteOriginMap[newsletter.alias] || website.get("origin");
+
 $ const logoStyles = {
   "border": "0",
   "font-size": "0",
@@ -22,5 +27,5 @@ $ const linkStyles = {
 }
 
 <marko-newsletter-imgix src=logoSrc options={ w: 200 } alt=alt attrs={ border: "0", width: "200", style: logoStyles }>
-  <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
+  <@link href=origin attrs={ style: linkStyles } target="_blank" />
 </marko-newsletter-imgix>

--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -423,8 +423,6 @@ const config = {
   'aad-aesthetics': {
     ...brands.aad,
     name: 'AAD Aesthetics',
-    customWebsite: 'https://www.aadmeetingnews.org/aesthetics',
-    useCustomWebsite: true,
     description: 'ePREVIEW',
     headerImageSrc: '/files/base/ascend/hh/image/static/aad/AestheticsNews_DW_header.jpeg',
     footer: {

--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -423,6 +423,8 @@ const config = {
   'aad-aesthetics': {
     ...brands.aad,
     name: 'AAD Aesthetics',
+    customWebsite: 'https://www.aadmeetingnews.org/aesthetics',
+    useCustomWebsite: true,
     description: 'ePREVIEW',
     headerImageSrc: '/files/base/ascend/hh/image/static/aad/AestheticsNews_DW_header.jpeg',
     footer: {

--- a/tenants/all/templates/aad-aesthetics.marko
+++ b/tenants/all/templates/aad-aesthetics.marko
@@ -18,7 +18,7 @@ $ const nativeX = config.getAsObject("nativeX");
     <common-head-block />
   </@head>
   <@body style="padding:0; margin:0;font-family: 'Roboto', Arial, sans-serif; -webkit-text-size-adjust:100%;">
-    <common-body-wrapper-block newsletter=newsletter date=date footer=input.footer>
+    <common-body-wrapper-block newsletter=newsletter date=date>
       <@body>
 
         <!-- Ad Slot 1 -->


### PR DESCRIPTION
<img width="1102" alt="Screenshot 2024-04-29 at 10 42 31 AM" src="https://github.com/parameter1/ascend-media-newsletters/assets/64623209/97124310-2ce4-4a06-9e5c-202f6835a760">

Shows default website works for other templates:
<img width="1027" alt="Screenshot 2024-04-29 at 10 42 44 AM" src="https://github.com/parameter1/ascend-media-newsletters/assets/64623209/598b2328-1c67-458e-b40b-64d2759c57f5">
