### PR TITLE
Use aha-footer for ss-epreview(international) expanded templates

### DIFF
--- a/tenants/all/templates/aha-ss-epreview-expanded.marko
+++ b/tenants/all/templates/aha-ss-epreview-expanded.marko
@@ -305,6 +305,9 @@ $ const nativeX = config.getAsObject("nativeX");
         <!-- Channels -->
         <common-channel-buttons-block newsletter=newsletter />
       </@body>
+      <@footer>
+        <common-footer-aha-block date=date newsletter=newsletter />
+      </@footer>
     </common-body-wrapper-block>
   </@body>
 </marko-newsletter-root>

--- a/tenants/all/templates/aha-ss-international-expanded.marko
+++ b/tenants/all/templates/aha-ss-international-expanded.marko
@@ -305,6 +305,9 @@ $ const nativeX = config.getAsObject("nativeX");
         <!-- Channels -->
         <common-channel-buttons-block newsletter=newsletter />
       </@body>
+      <@footer>
+        <common-footer-aha-block date=date newsletter=newsletter />
+      </@footer>
     </common-body-wrapper-block>
   </@body>
 </marko-newsletter-root>


### PR DESCRIPTION
SS ePreview (International):
<img width="1137" alt="Screenshot 2024-10-24 at 8 47 08 AM" src="https://github.com/user-attachments/assets/a508f2c5-1c52-4ae5-b01f-fe8066591e28">
<img width="1284" alt="Screenshot 2024-10-24 at 8 47 24 AM" src="https://github.com/user-attachments/assets/5274f742-fd3e-43fe-8e46-a7260ee9d2d3">


SS ePreview (International) currently using aha-footer:
<img width="1207" alt="Screenshot 2024-10-24 at 8 47 30 AM" src="https://github.com/user-attachments/assets/e6ff670a-e337-458c-a069-e43bd126f720">
